### PR TITLE
Re-export types through a renamed import

### DIFF
--- a/src/common/Role.tsx
+++ b/src/common/Role.tsx
@@ -1,8 +1,8 @@
 import React, {useContext} from "react";
 
-import {IUser} from "./userTypes";
+import {IUser as IRealUser} from "./userTypes";
+export type IUser = IRealUser;
 
-export type IUser = IUser;
 export const UserContext = React.createContext<IUser | null>(null);
 
 interface RoleProps {

--- a/src/common/userTypes.ts
+++ b/src/common/userTypes.ts
@@ -1,8 +1,11 @@
-import {AppQuery, AppQueryResponse} from "../__generated__/AppQuery.graphql";
+import {
+  AppQuery as OAppQuery,
+  AppQueryResponse as OAppQueryResponse,
+} from "../__generated__/AppQuery.graphql";
 import {QueryResult} from "./Transport";
 
-export type AppQuery = AppQuery;
-export type AppQueryResponse = AppQueryResponse;
+export type AppQuery = OAppQuery;
+export type AppQueryResponse = OAppQueryResponse;
 export type AppQueryResult = QueryResult<AppQuery>;
 
 export type IUser = AppQueryResponse["users"]["me"];

--- a/src/quotes/queryTypes.ts
+++ b/src/quotes/queryTypes.ts
@@ -1,27 +1,27 @@
 import {
-  QuotePageQuery,
-  QuotePageQueryVariables,
-  QuotePageQueryResponse,
+  QuotePageQuery as OQuotePageQuery,
+  QuotePageQueryVariables as OQuotePageQueryVariables,
+  QuotePageQueryResponse as OQuotePageQueryResponse,
 } from "../__generated__/QuotePageQuery.graphql";
 
 import {
-  RandomQuoteQuery,
-  RandomQuoteQueryVariables,
-  RandomQuoteQueryResponse,
+  RandomQuoteQuery as ORandomQuoteQuery,
+  RandomQuoteQueryVariables as ORandomQuoteQueryVariables,
+  RandomQuoteQueryResponse as ORandomQuoteQueryResponse,
 } from "../__generated__/RandomQuoteQuery.graphql";
 
 import {QueryResult} from "../common/Transport";
 
-export type QuotePageQuery = QuotePageQuery;
-export type QuotePageQueryResponse = QuotePageQueryResponse;
-export type QuotePageQueryVariables = QuotePageQueryVariables;
+export type QuotePageQuery = OQuotePageQuery;
+export type QuotePageQueryResponse = OQuotePageQueryResponse;
+export type QuotePageQueryVariables = OQuotePageQueryVariables;
 export type QuotePageResult = QueryResult<QuotePageQuery>;
 
 export type IQuotes = NonNullable<
   QuotePageQueryResponse["documents"]
 >["all"]["edges"];
 
-export type RandomQuoteQuery = RandomQuoteQuery;
-export type RandomQuoteQueryVariables = RandomQuoteQueryVariables;
-export type RandomQuoteQueryResponse = RandomQuoteQueryResponse;
+export type RandomQuoteQuery = ORandomQuoteQuery;
+export type RandomQuoteQueryVariables = ORandomQuoteQueryVariables;
+export type RandomQuoteQueryResponse = ORandomQuoteQueryResponse;
 export type RandomQuoteResult = QueryResult<RandomQuoteQuery>;

--- a/src/recent/queryTypes.ts
+++ b/src/recent/queryTypes.ts
@@ -1,25 +1,25 @@
 import {QueryResult} from "../common/Transport";
 
 import {
-  RecentChannelQuery,
-  RecentChannelQueryVariables,
-  RecentChannelQueryResponse,
+  RecentChannelQuery as ORecentChannelQuery,
+  RecentChannelQueryVariables as ORecentChannelQueryVariables,
+  RecentChannelQueryResponse as ORecentChannelQueryResponse,
 } from "../__generated__/RecentChannelQuery.graphql";
 
 import {
-  RecentHistoryQuery,
-  RecentHistoryQueryVariables,
-  RecentHistoryQueryResponse,
+  RecentHistoryQuery as ORecentHistoryQuery,
+  RecentHistoryQueryVariables as ORecentHistoryQueryVariables,
+  RecentHistoryQueryResponse as ORecentHistoryQueryResponse,
 } from "../__generated__/RecentHistoryQuery.graphql";
 
-export type RecentChannelQuery = RecentChannelQuery;
-export type RecentChannelQueryVariables = RecentChannelQueryVariables;
-export type RecentChannelQueryResponse = RecentChannelQueryResponse;
+export type RecentChannelQuery = ORecentChannelQuery;
+export type RecentChannelQueryVariables = ORecentChannelQueryVariables;
+export type RecentChannelQueryResponse = ORecentChannelQueryResponse;
 export type RecentChannelResult = QueryResult<RecentChannelQuery>;
 
-export type RecentHistoryQuery = RecentHistoryQuery;
-export type RecentHistoryQueryVariables = RecentHistoryQueryVariables;
-export type RecentHistoryQueryResponse = RecentHistoryQueryResponse;
+export type RecentHistoryQuery = ORecentHistoryQuery;
+export type RecentHistoryQueryVariables = ORecentHistoryQueryVariables;
+export type RecentHistoryQueryResponse = ORecentHistoryQueryResponse;
 export type RecentHistoryResult = QueryResult<RecentHistoryQuery>;
 
 export type ILine = NonNullable<

--- a/src/rem/memoryTypes.ts
+++ b/src/rem/memoryTypes.ts
@@ -1,14 +1,14 @@
 import {
-  RandomMemoryListQuery,
-  RandomMemoryListQueryVariables,
-  RandomMemoryListQueryResponse,
+  RandomMemoryListQuery as ORandomMemoryListQuery,
+  RandomMemoryListQueryVariables as ORandomMemoryListQueryVariables,
+  RandomMemoryListQueryResponse as ORandomMemoryListQueryResponse,
 } from "../__generated__/RandomMemoryListQuery.graphql";
 
 import {QueryResult} from "../common/Transport";
 
-export type RandomMemoryListQuery = RandomMemoryListQuery;
-export type RandomMemoryListQueryVariables = RandomMemoryListQueryVariables;
-export type RandomMemoryListQueryResponse = RandomMemoryListQueryResponse;
+export type RandomMemoryListQuery = ORandomMemoryListQuery;
+export type RandomMemoryListQueryVariables = ORandomMemoryListQueryVariables;
+export type RandomMemoryListQueryResponse = ORandomMemoryListQueryResponse;
 
 export type RandomMemoryListResult = QueryResult<RandomMemoryListQuery>;
 


### PR DESCRIPTION
This corrects a compilation error caused by the TypeScript upgrade.